### PR TITLE
Extract default column adapters to separate module

### DIFF
--- a/adapters/primitive-adapters/build.gradle
+++ b/adapters/primitive-adapters/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+archivesBaseName = 'sqldelight-primitive-adapters'
+
+dependencies {
+    api project(':runtime')
+
+    testImplementation deps.junit
+    testImplementation deps.truth
+}
+
+apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/adapters/primitive-adapters/gradle.properties
+++ b/adapters/primitive-adapters/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=primitive-adapters
+POM_NAME=SQLDelight Primitive Column Adapters
+POM_DESCRIPTION=Primitive column adapters for SQLDelight
+POM_PACKAGING=jar

--- a/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/BooleanColumnAdapter.kt
+++ b/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/BooleanColumnAdapter.kt
@@ -1,0 +1,9 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.squareup.sqldelight.ColumnAdapter
+
+object BooleanColumnAdapter : ColumnAdapter<Boolean, Long> {
+  override fun decode(databaseValue: Long): Boolean = databaseValue == 1L
+
+  override fun encode(value: Boolean): Long = if (value) 1L else 0L
+}

--- a/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/DoubleColumnAdapter.kt
+++ b/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/DoubleColumnAdapter.kt
@@ -1,0 +1,9 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.squareup.sqldelight.ColumnAdapter
+
+object DoubleColumnAdapter : ColumnAdapter<Double, Long> {
+  override fun decode(databaseValue: Long): Double = databaseValue.toDouble()
+
+  override fun encode(value: Double): Long = value.toLong()
+}

--- a/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/FloatColumnAdapter.kt
+++ b/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/FloatColumnAdapter.kt
@@ -1,0 +1,9 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.squareup.sqldelight.ColumnAdapter
+
+object FloatColumnAdapter : ColumnAdapter<Float, Long> {
+  override fun decode(databaseValue: Long): Float = databaseValue.toFloat()
+
+  override fun encode(value: Float): Long = value.toLong()
+}

--- a/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/IntColumnAdapter.kt
+++ b/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/IntColumnAdapter.kt
@@ -1,0 +1,9 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.squareup.sqldelight.ColumnAdapter
+
+object IntColumnAdapter : ColumnAdapter<Int, Long> {
+  override fun decode(databaseValue: Long): Int = databaseValue.toInt()
+
+  override fun encode(value: Int): Long = value.toLong()
+}

--- a/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/ShortColumnAdapter.kt
+++ b/adapters/primitive-adapters/src/main/kotlin/com/squareup/sqldelight/adapter/primitive/ShortColumnAdapter.kt
@@ -1,0 +1,9 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.squareup.sqldelight.ColumnAdapter
+
+object ShortColumnAdapter : ColumnAdapter<Short, Long> {
+  override fun decode(databaseValue: Long): Short = databaseValue.toShort()
+
+  override fun encode(value: Short): Long = value.toLong()
+}

--- a/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/BooleanColumnAdapterTest.kt
+++ b/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/BooleanColumnAdapterTest.kt
@@ -1,0 +1,17 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BooleanColumnAdapterTest {
+  @Test fun decode() {
+    assertThat(BooleanColumnAdapter.decode(0L)).isFalse()
+    assertThat(BooleanColumnAdapter.decode(1L)).isTrue()
+    assertThat(BooleanColumnAdapter.decode(2L)).isFalse()
+  }
+
+  @Test fun encode() {
+    assertThat(BooleanColumnAdapter.encode(false)).isEqualTo(0)
+    assertThat(BooleanColumnAdapter.encode(true)).isEqualTo(1)
+  }
+}

--- a/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/DoubleColumnAdapterTest.kt
+++ b/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/DoubleColumnAdapterTest.kt
@@ -1,0 +1,14 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DoubleColumnAdapterTest {
+  @Test fun decode() {
+    assertThat(DoubleColumnAdapter.decode(10)).isEqualTo(10.0)
+  }
+
+  @Test fun encode() {
+    assertThat(DoubleColumnAdapter.encode(10.7)).isEqualTo(10)
+  }
+}

--- a/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/FloatColumnAdapterTest.kt
+++ b/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/FloatColumnAdapterTest.kt
@@ -1,0 +1,14 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class FloatColumnAdapterTest {
+  @Test fun decode() {
+    assertThat(FloatColumnAdapter.decode(10)).isEqualTo(10.0f)
+  }
+
+  @Test fun encode() {
+    assertThat(FloatColumnAdapter.encode(10.7f)).isEqualTo(10)
+  }
+}

--- a/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/IntColumnAdapterTest.kt
+++ b/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/IntColumnAdapterTest.kt
@@ -1,0 +1,14 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class IntColumnAdapterTest {
+  @Test fun decode() {
+    assertThat(IntColumnAdapter.decode(10)).isEqualTo(10)
+  }
+
+  @Test fun encode() {
+    assertThat(IntColumnAdapter.encode(10)).isEqualTo(10)
+  }
+}

--- a/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/ShortColumnAdapterTest.kt
+++ b/adapters/primitive-adapters/src/test/kotlin/com/squareup/sqldelight/adapter/primitive/ShortColumnAdapterTest.kt
@@ -1,0 +1,14 @@
+package com.squareup.sqldelight.adapter.primitive
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ShortColumnAdapterTest {
+  @Test fun decode() {
+    assertThat(ShortColumnAdapter.decode(10)).isEqualTo(10)
+  }
+
+  @Test fun encode() {
+    assertThat(ShortColumnAdapter.encode(10)).isEqualTo(10)
+  }
+}

--- a/docs/common/custom_column_types.md
+++ b/docs/common/custom_column_types.md
@@ -3,6 +3,7 @@
 If you'd like to retrieve columns as custom types you can specify a Kotlin type:
 
 ```sql
+import kotlin.String;
 import kotlin.collections.List;
 
 CREATE TABLE hockeyPlayer (
@@ -30,6 +31,24 @@ val queryWrapper: Database = Database(
   )
 )
 ```
+
+## Primitives
+
+A sibling module that adapts primitives for your convenience.
+
+```groovy
+dependencies {
+  implementation "com.squareup.sqldelight:jdbc-driver:{{ versions.sqldelight }}"
+}
+```
+
+The following adapters exist:
+
+- `BooleanColumnAdapter` — Retrieves `kotlin.Boolean` for an SQL type implicitly stored as `kotlin.Long`
+- `DoubleColumnAdapter` — Retrieves `kotlin.Double` for an SQL type implicitly stored as `kotlin.Long`
+- `FloatColumnAdapter` — Retrieves `kotlin.Float` for an SQL type implicitly stored as `kotlin.Long`
+- `IntColumnAdapter` — Retrieves `kotlin.Int` for an SQL type implicitly stored as `kotlin.Long`
+- `ShortColumnAdapter` — Retrieves `kotlin.Short` for an SQL type implicitly stored as `kotlin.Long`
 
 ## Enums
 

--- a/docs/common/types_server_migrations.md
+++ b/docs/common/types_server_migrations.md
@@ -4,6 +4,7 @@ If migrations are the schema's source of truth, you can also specify
 the exposed kotlin type when altering a table:
 
 ```sql
+import kotlin.String;
 import kotlin.collection.List;
 
 ALTER TABLE my_table

--- a/docs/common/types_sqlite.md
+++ b/docs/common/types_sqlite.md
@@ -1,7 +1,7 @@
 ## SQLite Types
 
 SQLDelight column definitions are identical to regular SQLite column definitions but support an [extra column constraint](#custom-column-types)
-which specifies the Kotlin type of the column in the generated interface. SQLDelight natively supports Long, Double, String, ByteArray, Int, Short, Float, and Booleans.
+which specifies the Kotlin type of the column in the generated interface.
 
 ```sql
 CREATE TABLE some_types (
@@ -9,16 +9,5 @@ CREATE TABLE some_types (
   some_double REAL,            -- Stored as REAL in db, retrieved as Double
   some_string TEXT,            -- Stored as TEXT in db, retrieved as String
   some_blob BLOB,              -- Stored as BLOB in db, retrieved as ByteArray
-  some_int INTEGER AS Int,     -- Stored as INTEGER in db, retrieved as Int
-  some_short INTEGER AS Short, -- Stored as INTEGER in db, retrieved as Short
-  some_float REAL AS Float     -- Stored as REAL in db, retrieved as Float
 );
-```
-
-Boolean columns are stored in the db as `INTEGER`, and so they can be given `INTEGER` column constraints. Use `DEFAULT 0` to default to false, for example.
-
-```sql
-CREATE TABLE hockey_player (
-  injured INTEGER AS Boolean DEFAULT 0
-)
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'sqldelight'
 
+include ':adapters:primitive-adapters'
 include ':drivers:android-driver'
 include ':drivers:jdbc-driver'
 include ':drivers:native-driver'

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -19,13 +19,8 @@ import com.alecstrong.sql.psi.core.psi.Queryable
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
 import com.intellij.psi.util.PsiTreeUtil
-import com.squareup.kotlinpoet.BOOLEAN
-import com.squareup.kotlinpoet.BYTE
 import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.kotlinpoet.FLOAT
-import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.sqldelight.core.compiler.integration.adapterName
@@ -87,14 +82,14 @@ internal data class IntermediateType(
     val value = (column?.columnType as ColumnTypeMixin?)?.adapter()?.let { adapter ->
       val adapterName = PsiTreeUtil.getParentOfType(column, Queryable::class.java)!!.tableExposed().adapterName
       dialectType.encode(CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.encode($name)", adapter))
-    } ?: when (javaType.copy(nullable = false)) {
-      FLOAT -> CodeBlock.of("$name.toDouble()")
-      BYTE -> CodeBlock.of("$name.toLong()")
-      SHORT -> CodeBlock.of("$name.toLong()")
-      INT -> CodeBlock.of("$name.toLong()")
-      BOOLEAN -> CodeBlock.of("if ($name) 1L else 0L")
-      else -> {
-        return dialectType.prepareStatementBinder(columnIndex, dialectType.encode(CodeBlock.of(this.name)))
+    } ?: run {
+      val decodedType = CodeBlock.of(name)
+      val encodedType = dialectType.encode(decodedType)
+
+      if (decodedType == encodedType) {
+        return dialectType.prepareStatementBinder(columnIndex, CodeBlock.of(this.name))
+      } else {
+        encodedType
       }
     }
 
@@ -126,18 +121,15 @@ internal data class IntermediateType(
       } else {
         CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.decode(%L)", adapter, dialectType.decode(cursorGetter))
       }
-    } ?: when (javaType) {
-      FLOAT -> CodeBlock.of("$cursorGetter.toFloat()")
-      FLOAT.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toFloat()")
-      BYTE -> CodeBlock.of("$cursorGetter.toByte()")
-      BYTE.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toByte()")
-      SHORT -> CodeBlock.of("$cursorGetter.toShort()")
-      SHORT.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toShort()")
-      INT -> CodeBlock.of("$cursorGetter.toInt()")
-      INT.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toInt()")
-      BOOLEAN -> CodeBlock.of("$cursorGetter == 1L")
-      BOOLEAN.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.let { it == 1L }")
-      else -> cursorGetter
+    } ?: run {
+      val encodedType = cursorGetter
+      val decodedType = dialectType.decode(encodedType)
+
+      if (javaType.isNullable && encodedType != decodedType) {
+        CodeBlock.of("%L?.let { %L }", cursorGetter, dialectType.decode(CodeBlock.of("it")))
+      } else {
+        decodedType
+      }
     }
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/ColumnTypeMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/ColumnTypeMixin.kt
@@ -23,17 +23,11 @@ import com.alecstrong.sql.psi.core.psi.impl.SqlColumnTypeImpl
 import com.intellij.lang.ASTNode
 import com.squareup.kotlinpoet.ARRAY
 import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.kotlinpoet.DOUBLE
-import com.squareup.kotlinpoet.FLOAT
-import com.squareup.kotlinpoet.INT
-import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.joinToCode
@@ -79,7 +73,7 @@ internal abstract class ColumnTypeMixin(
     val columnName = (parent as SqlColumnDef).columnName
     javaTypeName?.let {
       val customType = try {
-        it.parameterizedJavaType?.type() ?: return null
+        it.parameterizedJavaType.type()
       } catch (e: IllegalArgumentException) {
         // Found an invalid type.
         return null
@@ -95,11 +89,11 @@ internal abstract class ColumnTypeMixin(
   }
 
   private fun SqlDelightJavaTypeName.type(): TypeName? {
-    try {
-      return parameterizedJavaType?.type() ?: kotlinType(text)
+    return try {
+      parameterizedJavaType.type()
     } catch (e: IllegalArgumentException) {
       // Found an invalid type.
-      return null
+      null
     }
   }
 
@@ -171,18 +165,6 @@ internal abstract class ColumnTypeMixin(
 
   companion object {
     private val columnAdapterType = ClassName("com.squareup.sqldelight", "ColumnAdapter")
-
-    internal fun kotlinType(text: String) = when (text) {
-      "Integer", "Int" -> INT
-      "Boolean" -> BOOLEAN
-      "Short" -> SHORT
-      "Long" -> LONG
-      "Float" -> FLOAT
-      "Double" -> DOUBLE
-      "String" -> String::class.asClassName()
-      "ByteArray" -> ByteArray::class.asClassName()
-      else -> null
-    }
 
     internal val TypeName.isArrayType get() = when (this) {
       is ParameterizedTypeName -> rawType == ARRAY

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/JavaTypeMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/JavaTypeMixin.kt
@@ -38,9 +38,6 @@ abstract class JavaTypeMixin(
       )
     }
 
-    private fun typeForThisPackage(text: String) = when (ColumnTypeMixin.kotlinType(text)) {
-      null -> "${(containingFile as SqlDelightFile).packageName}.$text"
-      else -> text
-    }
+    private fun typeForThisPackage(text: String) = "${(containingFile as SqlDelightFile).packageName}.$text"
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/sqldelight.bnf
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/sqldelight.bnf
@@ -85,16 +85,7 @@ annotation_value ::= java_type_name '::class'
                    | {numeric_literal}
                    | '[' annotation_value ( ',' annotation_value ) * ']'
                    | annotation
-java_type_name ::= 'Boolean'
-            | 'Short'
-            | 'Int'
-            | 'Integer'
-            | 'Long'
-            | 'Float'
-            | 'Double'
-            | 'String'
-            | 'ByteArray'
-            | parameterized_java_type
+java_type_name ::= parameterized_java_type
 parameterized_java_type ::= java_type ( ( '<' java_type_name ( ',' java_type_name )* '>' )
                           | ( '<' ( java_type_name ',' )* java_type '<' java_type_name2 ( ',' java_type_name2 )* '>>' ) )?
 java_type_name2 ::= java_type

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -352,6 +352,7 @@ class MutatorQueryFunctionTest {
   @Test fun `bind parameters on custom types`() {
     val file = FixtureCompiler.parseSql(
       """
+      |import kotlin.String;
       |import kotlin.collections.List;
       |
       |CREATE TABLE paymentHistoryConfig (

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -20,8 +20,8 @@ class MutatorQueryTypeTest {
     val file = FixtureCompiler.parseSql(
       """
       |CREATE TABLE data (
-      |  id INTEGER AS Int PRIMARY KEY,
-      |  value TEXT AS kotlin.collections.List<String>
+      |  id INTEGER AS kotlin.Int PRIMARY KEY,
+      |  value TEXT AS kotlin.collections.List<kotlin.String>
       |);
       |
       |insertData:
@@ -41,7 +41,7 @@ class MutatorQueryTypeTest {
       |  |INSERT INTO data
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
-      |    bindLong(1, id?.let { it.toLong() })
+      |    bindLong(1, id?.let { database.data_Adapter.idAdapter.encode(it) })
       |    bindString(2, value?.let { database.data_Adapter.valueAdapter.encode(it) })
       |  }
       |}
@@ -56,7 +56,7 @@ class MutatorQueryTypeTest {
       |  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       |  packageName TEXT NOT NULL,
       |  className TEXT NOT NULL,
-      |  deprecated INTEGER AS Boolean NOT NULL DEFAULT 0,
+      |  deprecated INTEGER AS kotlin.Boolean NOT NULL DEFAULT 0,
       |  link TEXT NOT NULL,
       |
       |  UNIQUE (packageName, className)
@@ -91,7 +91,7 @@ class MutatorQueryTypeTest {
       |  |WHERE packageName = ?
       |  |  AND className = ?
       |  ""${'"'}.trimMargin(), 4) {
-      |    bindLong(1, if (deprecated) 1L else 0L)
+      |    bindLong(1, database.itemAdapter.deprecatedAdapter.encode(deprecated))
       |    bindString(2, link)
       |    bindString(3, packageName)
       |    bindString(4, className)
@@ -105,8 +105,8 @@ class MutatorQueryTypeTest {
     val file = FixtureCompiler.parseSql(
       """
       |CREATE TABLE data (
-      |  id INTEGER AS Int PRIMARY KEY,
-      |  value TEXT AS kotlin.collections.List<String>
+      |  id INTEGER AS kotlin.Int PRIMARY KEY,
+      |  value TEXT AS kotlin.collections.List<kotlin.String>
       |);
       |
       |selectForId:
@@ -131,7 +131,7 @@ class MutatorQueryTypeTest {
       |  |INSERT INTO data
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
-      |    bindLong(1, id?.let { it.toLong() })
+      |    bindLong(1, id?.let { database.data_Adapter.idAdapter.encode(it) })
       |    bindString(2, value?.let { database.data_Adapter.valueAdapter.encode(it) })
       |  }
       |  notifyQueries(${mutator.id}, {database.dataQueries.selectForId})
@@ -154,8 +154,8 @@ class MutatorQueryTypeTest {
     val file = FixtureCompiler.parseSql(
       """
       |CREATE TABLE data (
-      |  id INTEGER AS Int PRIMARY KEY,
-      |  value TEXT AS kotlin.collections.List<String>
+      |  id INTEGER AS kotlin.Int PRIMARY KEY,
+      |  value TEXT AS kotlin.collections.List<kotlin.String>
       |);
       |
       |insertData:
@@ -175,7 +175,7 @@ class MutatorQueryTypeTest {
       |  |INSERT INTO data
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
-      |    bindLong(1, id?.let { it.toLong() })
+      |    bindLong(1, id?.let { database.data_Adapter.idAdapter.encode(it) })
       |    bindString(2, value?.let { database.data_Adapter.valueAdapter.encode(it) })
       |  }
       |  notifyQueries(${mutator.id}, {database.otherDataQueries.selectForId})
@@ -202,8 +202,8 @@ class MutatorQueryTypeTest {
     val file = FixtureCompiler.parseSql(
       """
       |CREATE TABLE data (
-      |  id INTEGER AS Int NOT NULL PRIMARY KEY,
-      |  value TEXT AS kotlin.collections.List<String>
+      |  id INTEGER AS kotlin.Int NOT NULL PRIMARY KEY,
+      |  value TEXT AS kotlin.collections.List<kotlin.String>
       |);
       |
       |selectForId:
@@ -228,7 +228,7 @@ class MutatorQueryTypeTest {
       |  |INSERT INTO data
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
-      |    bindLong(1, id?.let { it.toLong() })
+      |    bindLong(1, id?.let { database.data_Adapter.idAdapter.encode(it) })
       |    bindString(2, value?.let { database.data_Adapter.valueAdapter.encode(it) })
       |  }
       |}
@@ -240,8 +240,8 @@ class MutatorQueryTypeTest {
     val file = FixtureCompiler.parseSql(
       """
       |CREATE TABLE data (
-      |  id INTEGER AS Int PRIMARY KEY,
-      |  value TEXT AS kotlin.collections.List<String>
+      |  id INTEGER AS kotlin.Int PRIMARY KEY,
+      |  value TEXT AS kotlin.collections.List<kotlin.String>
       |);
       |
       |insertData:
@@ -261,7 +261,7 @@ class MutatorQueryTypeTest {
       |  |INSERT INTO data
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
-      |    bindLong(1, id?.let { it.toLong() })
+      |    bindLong(1, id?.let { database.data_Adapter.idAdapter.encode(it) })
       |    bindString(2, value?.let { database.data_Adapter.valueAdapter.encode(it) })
       |  }
       |}
@@ -312,38 +312,6 @@ class MutatorQueryTypeTest {
       |  |)
       |  ""${'"'}.trimMargin(), 0)
       |  notifyQueries(${mutator.id}, {database.dataQueries.selectForId})
-      |}
-      |""".trimMargin()
-    )
-  }
-
-  @Test fun `non null boolean binds fine`() {
-    val file = FixtureCompiler.parseSql(
-      """
-      |CREATE TABLE data (
-      |  id INTEGER AS Int PRIMARY KEY,
-      |  value INTEGER AS Boolean NOT NULL
-      |);
-      |
-      |insertData:
-      |INSERT INTO data (value)
-      |VALUES (?);
-      """.trimMargin(),
-      tempFolder, fileName = "Data.sq"
-    )
-
-    val mutator = file.namedMutators.first()
-    val generator = MutatorQueryGenerator(mutator)
-
-    assertThat(generator.function().toString()).isEqualTo(
-      """
-      |public override fun insertData(value: kotlin.Boolean): kotlin.Unit {
-      |  driver.execute(${mutator.id}, ""${'"'}
-      |  |INSERT INTO data (value)
-      |  |VALUES (?)
-      |  ""${'"'}.trimMargin(), 1) {
-      |    bindLong(1, if (value) 1L else 0L)
-      |  }
       |}
       |""".trimMargin()
     )
@@ -672,7 +640,7 @@ class MutatorQueryTypeTest {
       |  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       |  packageName TEXT NOT NULL,
       |  className TEXT NOT NULL,
-      |  deprecated INTEGER AS Boolean NOT NULL DEFAULT 0,
+      |  deprecated INTEGER AS kotlin.Boolean NOT NULL DEFAULT 0,
       |  link TEXT NOT NULL,
       |
       |  UNIQUE (packageName, className)
@@ -708,7 +676,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}INSERT OR FAIL INTO item(packageName, className, deprecated, link) VALUES (?, ?, ?, ?)""${'"'}, 4) {
       |    bindString(1, packageName)
       |    bindString(2, className)
-      |    bindLong(3, if (deprecated) 1L else 0L)
+      |    bindLong(3, database.itemAdapter.deprecatedAdapter.encode(deprecated))
       |    bindString(4, link)
       |  }
       |  notifyQueries(${mutator.id}, {database.dataQueries.queryTerm})

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
@@ -25,6 +25,7 @@ class InterfaceGeneration {
       |import com.sample.SomeAnnotation;
       |import com.sample.SomeOtherAnnotation;
       |import java.util.List;
+      |import kotlin.Int;
       |
       |CREATE TABLE test (
       |  annotated INTEGER AS @SomeAnnotation(
@@ -47,8 +48,10 @@ class InterfaceGeneration {
       |
       |import com.sample.SomeAnnotation
       |import com.sample.SomeOtherAnnotation
+      |import com.squareup.sqldelight.ColumnAdapter
       |import java.util.List
       |import kotlin.Int
+      |import kotlin.Long
       |import kotlin.String
       |
       |public data class Test(
@@ -60,6 +63,10 @@ class InterfaceGeneration {
       |  |  annotated: ${"$"}annotated
       |  |]
       |  ""${'"'}.trimMargin()
+      |
+      |  public class Adapter(
+      |    public val annotatedAdapter: ColumnAdapter<Int, Long>
+      |  )
       |}
       |""".trimMargin()
     )
@@ -99,53 +106,6 @@ class InterfaceGeneration {
       |  |  get_cheese: ${"$"}get_cheese
       |  |  isle: ${"$"}isle
       |  |  stuff: ${"$"}stuff
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
-      |""".trimMargin()
-    )
-  }
-
-  @Test fun `kotlin types are inferred properly`() {
-    val result = FixtureCompiler.parseSql(
-      """
-      |CREATE TABLE test (
-      |  intValue INTEGER AS Int NOT NULL,
-      |  intValue2 INTEGER AS Integer NOT NULL,
-      |  booleanValue INTEGER AS Boolean NOT NULL,
-      |  shortValue INTEGER AS Short NOT NULL,
-      |  longValue INTEGER AS Long NOT NULL,
-      |  floatValue REAL AS Float NOT NULL,
-      |  doubleValue REAL AS Double NOT NULL,
-      |  blobValue BLOB AS ByteArray NOT NULL
-      |);
-      |""".trimMargin(),
-      tempFolder
-    )
-
-    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!.tableExposed())
-    assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo(
-      """
-      |public data class Test(
-      |  public val intValue: kotlin.Int,
-      |  public val intValue2: kotlin.Int,
-      |  public val booleanValue: kotlin.Boolean,
-      |  public val shortValue: kotlin.Short,
-      |  public val longValue: kotlin.Long,
-      |  public val floatValue: kotlin.Float,
-      |  public val doubleValue: kotlin.Double,
-      |  public val blobValue: kotlin.ByteArray
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Test [
-      |  |  intValue: ${"$"}intValue
-      |  |  intValue2: ${"$"}intValue2
-      |  |  booleanValue: ${"$"}booleanValue
-      |  |  shortValue: ${"$"}shortValue
-      |  |  longValue: ${"$"}longValue
-      |  |  floatValue: ${"$"}floatValue
-      |  |  doubleValue: ${"$"}doubleValue
-      |  |  blobValue: ${"$"}{blobValue.kotlin.collections.contentToString()}
       |  |]
       |  ""${'"'}.trimMargin()
       |}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
@@ -24,7 +24,7 @@ class InterfaceGeneration {
     val result = FixtureCompiler.compileSql(
       """
       |CREATE TABLE test (
-      |  val INTEGER AS Boolean NOT NULL
+      |  val INTEGER AS kotlin.Boolean NOT NULL
       |);
       |
       |CREATE VIEW someView AS
@@ -68,11 +68,11 @@ class InterfaceGeneration {
     val result = FixtureCompiler.compileSql(
       """
       |CREATE TABLE test (
-      |  val INTEGER AS Boolean NOT NULL
+      |  val INTEGER AS kotlin.Boolean NOT NULL
       |);
       |
       |CREATE TABLE another_test (
-      |  val INTEGER AS Boolean NOT NULL
+      |  val INTEGER AS kotlin.Boolean NOT NULL
       |);
       |
       |CREATE VIEW someView AS

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/2.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/2.sqm
@@ -1,3 +1,4 @@
+import kotlin.Int;
 import kotlin.collections.List;
 
 ALTER TABLE test ADD COLUMN second TEXT AS List<Int>;

--- a/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/com/sample/Data.sq
+++ b/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/com/sample/Data.sq
@@ -1,4 +1,5 @@
 import java.util.List;
+import kotlin.Boolean;
 import com.sample.Person;
 import com.squareup.Redacted;
 

--- a/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/com/sample/Data.sq
+++ b/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/com/sample/Data.sq
@@ -1,4 +1,5 @@
 import java.util.List;
+import kotlin.Boolean;
 import com.sample.Person;
 import com.squareup.Redacted;
 

--- a/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -31,6 +31,8 @@ public data class Person(
   """.trimMargin()
 
   public class Adapter(
-    public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>
+    public val is_coolAdapter: ColumnAdapter<Boolean, Long>,
+    public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>,
+    public val shhh_its_secretAdapter: ColumnAdapter<String, String>
   )
 }

--- a/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/com/sample/Data.sq
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/com/sample/Data.sq
@@ -1,4 +1,5 @@
 import java.util.List;
+import kotlin.Boolean;
 import com.sample.Person;
 import com.squareup.Redacted;
 

--- a/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
@@ -28,6 +28,8 @@ public data class Person(
   """.trimMargin()
 
   public class Adapter(
-    public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>
+    public val is_coolAdapter: ColumnAdapter<Boolean, Long>,
+    public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>,
+    public val shhh_its_secretAdapter: ColumnAdapter<String, String>
   )
 }

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/com/sample/Data.sq
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/com/sample/Data.sq
@@ -1,4 +1,5 @@
 import java.util.List;
+import kotlin.Boolean;
 import com.sample.Person;
 import com.squareup.Redacted;
 

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -28,6 +28,8 @@ public data class Person(
   """.trimMargin()
 
   public class Adapter(
-    public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>
+    public val is_coolAdapter: ColumnAdapter<Boolean, Long>,
+    public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>,
+    public val shhh_its_secretAdapter: ColumnAdapter<String, String>
   )
 }

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonMain/sqldelight/com/squareup/sqldelight/integration/NullableTypes.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonMain/sqldelight/com/squareup/sqldelight/integration/NullableTypes.sq
@@ -1,5 +1,5 @@
 CREATE TABLE nullableTypes (
-  val1 TEXT AS kotlin.collections.List<String>,
+  val1 TEXT AS kotlin.collections.List<kotlin.String>,
   val2 TEXT
 );
 

--- a/sqldelight-gradle-plugin/src/test/integration/src/main/sqldelight/com/squareup/sqldelight/integration/NullableTypes.sq
+++ b/sqldelight-gradle-plugin/src/test/integration/src/main/sqldelight/com/squareup/sqldelight/integration/NullableTypes.sq
@@ -1,5 +1,5 @@
 CREATE TABLE nullableTypes (
-  val1 TEXT AS kotlin.collections.List<String>,
+  val1 TEXT AS kotlin.collections.List<kotlin.String>,
   val2 TEXT
 );
 


### PR DESCRIPTION
Extracts the default column adapters for `Boolean`, `Double`, `Float`, `Int`, and `Short` into a new module named "primitive-adapters".